### PR TITLE
1.3.2 ssh fix

### DIFF
--- a/roles/prep_hosts/tasks/main.yml
+++ b/roles/prep_hosts/tasks/main.yml
@@ -14,6 +14,7 @@
   ansible.builtin.authorized_key:
     user: ansible
     key: "{{ lookup('file', prep_hosts_path) }}"
+  when: manage_service_account | default(true)
 
 - name: Make ansible sudo password-less
   ansible.builtin.lineinfile:
@@ -21,7 +22,9 @@
     state: "present"
     regexp: "^%ansible"
     line: "%ansible ALL=(ALL) NOPASSWD: ALL"
-  when: service_account_nopasswd | default(true)
+  when:
+    - manage_service_account | default(true)
+    - service_account_nopasswd | default(true)
 
 - name: Configure Hostname
   ansible.builtin.hostname:

--- a/roles/prep_hosts/tasks/main.yml
+++ b/roles/prep_hosts/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: Set a fact for the ssh_key file path
   ansible.builtin.set_fact:
     prep_hosts_path: "~/.ssh/{{ id_ed25519.pub | default('id_ed25519.pub') }}"
+  when: manage_service_account | default(true)
 
 - name: Add authorized keys
   ansible.builtin.authorized_key:


### PR DESCRIPTION
extended the use of the service account variable to other steps for managing the ssh key configuration. 